### PR TITLE
fix: make init fn recognizable by sqlite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 license = "AGPL-3.0-only"
 
 [lib]
-crate-type = ["rlib", "staticlib"]
+crate-type = ["rlib", "staticlib", "cdylib"]
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ symbols in full-text search.
 # Extension Build/Usage Example
 
 ```sh
-cargo rustc --features extension -- --crate-type=cdylib
+cargo build --features extension --release
 ```
 
-Load extension from `./target/release/libsignal_tokenizer.dylib`.
+Load extension from `./target/release/libsignal_tokenizer`.
 
 ```sql
 CREATE VIRTUAL TABLE
@@ -39,4 +39,3 @@ cbindgen --profile release . -o target/release/fts5-tokenizer.h
 Copyright 2023 Signal Messenger, LLC.
 
 Licensed under the AGPLv3: http://www.gnu.org/licenses/agpl-3.0.html
-

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -298,7 +298,7 @@ pub struct Sqlite3APIRoutines {
 }
 
 #[no_mangle]
-pub extern "C" fn signal_fts5_tokenizer_init(
+pub extern "C" fn sqlite3_signaltokenizer_init(
     db: *mut Sqlite3,
     _pz_err_msg: *mut *mut c_uchar,
     p_api: *const c_void,


### PR DESCRIPTION
- Renamed init function which is needed for sqlite in the way to follow pattern which is recognizable by db
- Added `cdylib` to Cargo.toml crate types to generate extension executable automatically
- Improved readme to work not only on macos and actually build for release target